### PR TITLE
Handle record creation & processing out of order

### DIFF
--- a/lib/rails-pipeline/handlers/activerecord_crud.rb
+++ b/lib/rails-pipeline/handlers/activerecord_crud.rb
@@ -8,7 +8,7 @@ module RailsPipeline
             return target_class.create!(_attributes(payload), without_protection: true)
           when RailsPipeline::EncryptedMessage::EventType::UPDATED
             # We might want to allow confiugration of the primary key field
-            object = target_class.find(payload.id)
+            object = target_class.where({id: payload.id}).first_or_create!
             object.update_attributes!(_attributes(payload), without_protection: true)
             return object
           when RailsPipeline::EncryptedMessage::EventType::DELETED

--- a/lib/rails-pipeline/handlers/activerecord_crud.rb
+++ b/lib/rails-pipeline/handlers/activerecord_crud.rb
@@ -7,7 +7,6 @@ module RailsPipeline
           when RailsPipeline::EncryptedMessage::EventType::CREATED
             return target_class.create!(_attributes(payload), without_protection: true)
           when RailsPipeline::EncryptedMessage::EventType::UPDATED
-            # We might want to allow confiugration of the primary key field
             object = target_class.where({id: payload.id}).first_or_create!
             object.update_attributes!(_attributes(payload), without_protection: true)
             return object
@@ -23,6 +22,12 @@ module RailsPipeline
 
       def _attributes(payload)
         attributes_hash = payload.to_hash
+
+        puts "teh attributes"
+        puts attributes_hash.inspect
+        puts "teh attributes"
+
+
         attributes_hash.each do |attribute_name, value|
           if attribute_name.match /_at$/
             attributes_hash[attribute_name] = Time.at(value).to_datetime

--- a/lib/rails-pipeline/handlers/activerecord_crud.rb
+++ b/lib/rails-pipeline/handlers/activerecord_crud.rb
@@ -1,40 +1,48 @@
 module RailsPipeline
-  module SubscriberHandler
-    class ActiveRecordCRUD < BaseHandler
-      def handle_payload
-        begin
-          case event_type
-          when RailsPipeline::EncryptedMessage::EventType::CREATED
-            return target_class.create!(_attributes(payload), without_protection: true)
-          when RailsPipeline::EncryptedMessage::EventType::UPDATED
-            object = target_class.where({id: payload.id}).first_or_create!
-            object.update_attributes!(_attributes(payload), without_protection: true)
-            return object
-          when RailsPipeline::EncryptedMessage::EventType::DELETED
-            object = target_class.find(payload.id)
-            object.destroy
-            return object
-          end
-        rescue ActiveRecord::StatementInvalid, ActiveRecord::RecordNotFound => e
-          RailsPipeline.logger.error "Could not handle payload: #{payload.inspect}, event_type: #{event_type}"
+    module SubscriberHandler
+        class ActiveRecordCRUD < BaseHandler
+            def handle_payload
+                case event_type
+                when RailsPipeline::EncryptedMessage::EventType::CREATED
+                    object = target_class.where({id: payload.id}).first
+                    if object.nil?
+                        ActiveRecord::Base.transaction do
+                            object = target_class.create!(_attributes(payload), without_protection: true)
+                        end
+                    end
+                    object
+                when RailsPipeline::EncryptedMessage::EventType::UPDATED
+                    object = target_class.where({id: payload.id}).first
+
+                    if object.nil?
+                        ActiveRecord::Base.transaction do
+                            object = target_class.create!(_attributes(payload), without_protection: true)
+                        end
+                    elsif object && (payload.updated_at.to_i >= object.updated_at.to_i)
+                        ActiveRecord::Base.transaction do
+                            object.update_attributes!(_attributes(payload), without_protection: true)
+                        end
+                    end
+
+                    object
+                when RailsPipeline::EncryptedMessage::EventType::DELETED
+                    object = target_class.find(payload.id)
+                    ActiveRecord::Base.transaction do
+                        object.destroy
+                    end
+                    object
+                end
+            end
+
+            def _attributes(payload)
+                attributes_hash = payload.to_hash
+                attributes_hash.each do |attribute_name, value|
+                    if attribute_name.match /_at$/
+                        attributes_hash[attribute_name] = Time.at(value).to_datetime
+                    end
+                end
+                return attributes_hash
+            end
         end
-      end
-
-      def _attributes(payload)
-        attributes_hash = payload.to_hash
-
-        puts "teh attributes"
-        puts attributes_hash.inspect
-        puts "teh attributes"
-
-
-        attributes_hash.each do |attribute_name, value|
-          if attribute_name.match /_at$/
-            attributes_hash[attribute_name] = Time.at(value).to_datetime
-          end
-        end
-        return attributes_hash
-      end
     end
-  end
 end

--- a/spec/dummy/app/models/test_model_with_table.rb
+++ b/spec/dummy/app/models/test_model_with_table.rb
@@ -7,6 +7,9 @@ class TestModelWithTable < ActiveRecord::Base
   include DummyPublisher
 
   def to_pipeline_1_1
-    TestEmitter_1_1.new(id: self.id, foo: (self.foo || 'foo'), created_at: self.created_at.to_i)
+    TestEmitter_1_1.new(id: self.id,
+                        foo: (self.foo || 'foo'),
+                        created_at: self.created_at.to_i,
+                        updated_at: self.updated_at.to_i)
   end
 end

--- a/spec/protobuf/test_emitter_1_1.pb.rb
+++ b/spec/protobuf/test_emitter_1_1.pb.rb
@@ -12,6 +12,7 @@ class TestEmitter_1_1 < ::ProtocolBuffers::Message
   required :int32, :id, 1
   required :string, :foo, 2
   optional :string, :extrah, 3
-  optional :double, :created_at, 4
+  optional :int32, :created_at, 4
+  optional :int32, :updated_at, 5
 end
 

--- a/spec/protobuf/test_emitter_1_1.proto
+++ b/spec/protobuf/test_emitter_1_1.proto
@@ -2,5 +2,6 @@ message TestEmitter__1__1 {
   required int32 id = 1;
   required string foo = 2;
   optional string extrah = 3;
-  optional string created_at = 4;
+  optional int32 created_at = 4;
+  optional int32 updated_at = 5;
 }


### PR DESCRIPTION
I will say that this pull request is opinionated, but thought it was worth running this by you. This could totally live in user space. 

This pull request adds the ability to process record creation & updates out of chronological order. The processing of deletions remain unmodified